### PR TITLE
Enable the use of an External ID for assuming a role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ functionality provided by the aws-sdk.
       awssume aws iam list-roles
 ```
 
+There are scenarios where you might want to [use an external id][aws_ext_id]
+in a condition on your assume role policy. For such cases, the gem will look
+for the ``AWS_ROLE_EXTERNAL_ID`` variable in your environment. If this variable
+is set the value will be sent allong in the STS Assume Role request.
+
+```
+  $ AWS_ROLE_ARN=arn::aws::iam::123456789012:role/RoletoAssume \
+    AWS_ROLE_EXTERNAL_ID=12345 \
+      awssume aws iam list-roles
+```
+
+[aws_ext_id]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/exe/awssume
+++ b/exe/awssume
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'awssume'
 Awssume.run

--- a/lib/awssume.rb
+++ b/lib/awssume.rb
@@ -10,7 +10,8 @@ module Awssume
     adapter = Awssume::Adapter::AwsClient.new(
       region:            config.region,
       role_arn:          config.role_arn,
-      role_session_name: config.role_session_name
+      role_session_name: config.role_session_name,
+      external_id:       config.external_id
     )
     aws_env = {
       'AWS_REGION'         => config.region,

--- a/lib/awssume/adapter/aws_client.rb
+++ b/lib/awssume/adapter/aws_client.rb
@@ -11,10 +11,7 @@ module Awssume
       end
 
       def assume
-        sts_client.assume_role(
-          role_arn: config[:role_arn],
-          role_session_name: role_session_name
-        ).credentials.to_h
+        sts_client.assume_role(assume_role_params).credentials.to_h
       end
 
       def role_session_name
@@ -22,6 +19,18 @@ module Awssume
       end
 
       private
+
+      def assume_role_params
+        p = {
+          role_arn: config[:role_arn],
+          role_session_name: role_session_name,
+          external_id: config[:external_id]
+        }
+
+        p.delete(:external_id) unless p[:external_id]
+
+        p
+      end
 
       def sts_client
         Aws::STS::Client.new(region: config[:region])

--- a/lib/awssume/version.rb
+++ b/lib/awssume/version.rb
@@ -1,3 +1,3 @@
 module Awssume
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/awssume/adapter/aws_client_spec.rb
+++ b/spec/awssume/adapter/aws_client_spec.rb
@@ -47,6 +47,23 @@ describe Awssume::Adapter::AwsClient do
       adapter.assume
     end
 
+    context 'with external id set' do
+      let(:adapter) do
+        c = config_hash.merge({external_id: '12345abc'})
+        Awssume::Adapter::AwsClient.new(c)
+      end
+
+      it 'should call assume_role with external id included' do
+        expect(sts_stub).to receive(:assume_role).with(
+          role_arn:          'arn:aws:iam::123456789012:role/aRole',
+          role_session_name: 'test-deploy',
+          external_id:       '12345abc'
+        )
+
+        adapter.assume
+      end
+    end
+
     context 'successful response' do
       subject(:response) { adapter.assume }
 

--- a/spec/awssume/configuration_spec.rb
+++ b/spec/awssume/configuration_spec.rb
@@ -27,6 +27,21 @@ describe Awssume::Configuration do
       end
     end
 
+    describe 'missing optional attributes' do
+      let(:valid_args) do
+        {
+          region: 'us-east-1',
+          role_arn: 'arn:aws:iam::123456789012:user/David',
+          role_session_name: 'testDeploy'
+        }
+      end
+
+      it 'does not raise error when optional attributes are missing' do
+        expect { Awssume::Configuration.new(valid_args) }
+          .not_to raise_error
+      end
+    end
+
     it 'should provide default session name if none is provided' do
       config = Awssume::Configuration.new(
         role_arn: 'arn:aws:iam::123456789012:user/David',
@@ -53,13 +68,15 @@ describe Awssume::Configuration do
         'ENV',
         'AWS_REGION'            => 'us-east-1',
         'AWS_ROLE_ARN'          => 'arn:aws:iam::123456789012:user/Gary',
-        'AWS_ROLE_SESSION_NAME' => 'testSessionName'
+        'AWS_ROLE_SESSION_NAME' => 'testSessionName',
+        'AWS_ROLE_EXTERNAL_ID'  => '12345abc'
       )
       config = Awssume::Configuration.new
 
       expect(config.region).to eq('us-east-1')
       expect(config.role_arn).to eq('arn:aws:iam::123456789012:user/Gary')
       expect(config.role_session_name).to eq('testSessionName')
+      expect(config.external_id).to eq('12345abc')
     end
 
     it 'can use AWS_DEFAULT_REGION for region' do

--- a/spec/awssume_spec.rb
+++ b/spec/awssume_spec.rb
@@ -8,7 +8,7 @@ describe Awssume do
   describe '.run' do
     before do
       fake_config = double('fake_config')
-      [:region, :role_arn, :role_session_name].each do |method|
+      [:region, :role_arn, :role_session_name, :external_id].each do |method|
         allow(fake_config).to receive(method)
       end
 


### PR DESCRIPTION
Opening a pull request for a suggested new feature.

> There are scenarios where you might want to [use an external id][aws_ext_id]
in a condition on your assume role policy. For such cases, the gem will look
for the ``AWS_ROLE_EXTERNAL_ID`` variable in your environment. If this variable
is set the value will be sent allong in the STS Assume Role request.

For to come in this thread. ~~Not ready to merge.~~