### PR TITLE
Add support for longer-than-1-hour AssumeRole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
-/vendor/bundle/
+/vendor/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can configure env vars to authenticate with AWS:
 ```
 
 If AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY aren't set then other
-authentication options are checked(such as instance profiles).  This is
+authentication options are checked (such as instance profiles).  This is
 functionality provided by the aws-sdk.
 
 ```
@@ -67,7 +67,7 @@ functionality provided by the aws-sdk.
 There are scenarios where you might want to [use an external id][aws_ext_id]
 in a condition on your assume role policy. For such cases, the gem will look
 for the ``AWS_ROLE_EXTERNAL_ID`` variable in your environment. If this variable
-is set the value will be sent allong in the STS Assume Role request.
+is set the value will be sent along in the STS Assume Role request.
 
 ```
   $ AWS_ROLE_ARN=arn::aws::iam::123456789012:role/RoletoAssume \
@@ -76,6 +76,18 @@ is set the value will be sent allong in the STS Assume Role request.
 ```
 
 [aws_ext_id]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+
+It's also possible to request credentials that
+[last longer than the default of one hour](https://aws.amazon.com/about-aws/whats-new/2018/03/longer-role-sessions/)
+if the role you're assuming is configured to support them (``MaxSessionDuration``
+greater than 3600 seconds). Here's an example of assuming 12-hour (43200 second; the maximum)
+credentials for a _really_ long-running command:
+
+```
+  $ AWS_ROLE_ARN=arn::aws::iam::123456789012:role/RoletoAssume \
+    AWS_ROLE_DURATION_SECONDS=43200 \
+      awssume really-long-running-command
+```
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,9 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task :default => [:help]
+
+desc "Display the list of available rake tasks"
+task :help do
+  system("rake -T")
+end

--- a/lib/awssume.rb
+++ b/lib/awssume.rb
@@ -11,7 +11,8 @@ module Awssume
       region:            config.region,
       role_arn:          config.role_arn,
       role_session_name: config.role_session_name,
-      external_id:       config.external_id
+      external_id:       config.external_id,
+      duration_seconds:  config.duration_seconds,
     )
     aws_env = {
       'AWS_REGION'         => config.region,

--- a/lib/awssume/adapter/aws_client.rb
+++ b/lib/awssume/adapter/aws_client.rb
@@ -24,10 +24,13 @@ module Awssume
         p = {
           role_arn: config[:role_arn],
           role_session_name: role_session_name,
-          external_id: config[:external_id]
+          external_id: config[:external_id],
+          duration_seconds: config[:duration_seconds],
         }
 
         p.delete(:external_id) unless p[:external_id]
+        p.delete(:duration_seconds) \
+          if p[:duration_seconds].nil? || p[:duration_seconds] == 0
 
         p
       end

--- a/lib/awssume/configuration.rb
+++ b/lib/awssume/configuration.rb
@@ -19,7 +19,8 @@ module Awssume
     # The utility will function without issue if an optional value is missing
     def self.options
       {
-        external_id: ENV['AWS_ROLE_EXTERNAL_ID']
+        external_id:       ENV['AWS_ROLE_EXTERNAL_ID'],
+        duration_seconds:  ENV['AWS_ROLE_DURATION_SECONDS'].to_i
       }
     end
 

--- a/lib/awssume/version.rb
+++ b/lib/awssume/version.rb
@@ -1,3 +1,3 @@
 module Awssume
-  VERSION = "0.3.0"
+  VERSION = "1.0.0"
 end

--- a/spec/awssume/adapter/aws_client_spec.rb
+++ b/spec/awssume/adapter/aws_client_spec.rb
@@ -64,6 +64,39 @@ describe Awssume::Adapter::AwsClient do
       end
     end
 
+    context 'with duration_seconds set' do
+      let(:adapter) do
+        c = config_hash.merge({duration_seconds: 43200})
+        Awssume::Adapter::AwsClient.new(c)
+      end
+
+      it 'should call assume_role with duration_seconds included' do
+        expect(sts_stub).to receive(:assume_role).with(
+          role_arn:          'arn:aws:iam::123456789012:role/aRole',
+          role_session_name: 'test-deploy',
+          duration_seconds:  43200
+        )
+
+        adapter.assume
+      end
+    end
+
+    context 'with duration_seconds unset' do
+      let(:adapter) do
+        c = config_hash.merge({duration_seconds: 0})
+        Awssume::Adapter::AwsClient.new(c)
+      end
+
+      it 'should call assume_role with duration_seconds included' do
+        expect(sts_stub).to receive(:assume_role).with(
+          role_arn:          'arn:aws:iam::123456789012:role/aRole',
+          role_session_name: 'test-deploy'
+        )
+
+        adapter.assume
+      end
+    end
+
     context 'successful response' do
       subject(:response) { adapter.assume }
 

--- a/spec/awssume/configuration_spec.rb
+++ b/spec/awssume/configuration_spec.rb
@@ -66,10 +66,11 @@ describe Awssume::Configuration do
     it 'can set attributes with env vars' do
       stub_const(
         'ENV',
-        'AWS_REGION'            => 'us-east-1',
-        'AWS_ROLE_ARN'          => 'arn:aws:iam::123456789012:user/Gary',
-        'AWS_ROLE_SESSION_NAME' => 'testSessionName',
-        'AWS_ROLE_EXTERNAL_ID'  => '12345abc'
+        'AWS_REGION'                => 'us-east-1',
+        'AWS_ROLE_ARN'              => 'arn:aws:iam::123456789012:user/Gary',
+        'AWS_ROLE_SESSION_NAME'     => 'testSessionName',
+        'AWS_ROLE_EXTERNAL_ID'      => '12345abc',
+        'AWS_ROLE_DURATION_SECONDS' => '43200',
       )
       config = Awssume::Configuration.new
 
@@ -77,6 +78,24 @@ describe Awssume::Configuration do
       expect(config.role_arn).to eq('arn:aws:iam::123456789012:user/Gary')
       expect(config.role_session_name).to eq('testSessionName')
       expect(config.external_id).to eq('12345abc')
+      expect(config.duration_seconds).to eq(43200)
+    end
+
+    it 'handles an unset AWS_ROLE_DURATION_SECONDS' do
+      stub_const(
+        'ENV',
+        'AWS_REGION'                => 'us-east-1',
+        'AWS_ROLE_ARN'              => 'arn:aws:iam::123456789012:user/Gary',
+        'AWS_ROLE_SESSION_NAME'     => 'testSessionName',
+        'AWS_ROLE_EXTERNAL_ID'      => '12345abc',
+      )
+      config = Awssume::Configuration.new
+
+      expect(config.region).to eq('us-east-1')
+      expect(config.role_arn).to eq('arn:aws:iam::123456789012:user/Gary')
+      expect(config.role_session_name).to eq('testSessionName')
+      expect(config.external_id).to eq('12345abc')
+      expect(config.duration_seconds).to eq(0)
     end
 
     it 'can use AWS_DEFAULT_REGION for region' do

--- a/spec/awssume_spec.rb
+++ b/spec/awssume_spec.rb
@@ -8,7 +8,9 @@ describe Awssume do
   describe '.run' do
     before do
       fake_config = double('fake_config')
-      [:region, :role_arn, :role_session_name, :external_id].each do |method|
+      [
+        :region, :role_arn, :role_session_name, :external_id, :duration_seconds
+      ].each do |method|
         allow(fake_config).to receive(method)
       end
 


### PR DESCRIPTION
This PR adds support for assuming roles for longer than one hour, using the [DurationSeconds support](https://aws.amazon.com/about-aws/whats-new/2018/03/longer-role-sessions/) released earlier this year.

Unit tests updated; tests pass, and also verified with manual exploratory testing.

This PR also:

* Fixes a few typos
* Bumps the version to 1.0.0 - we're using this in a _bunch_ of places on a daily basis
* Switches the default rake task from running specs, to printing a list of tasks